### PR TITLE
[codex] Add optional Docker Hub login for runner action

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -19,6 +19,9 @@ on:
       GH_SA_TOKEN:
         description: "GitHub token with permissions to manage self-hosted runners"
         required: true
+      DOCKERHUB_TOKEN:
+        description: "Docker Hub token used to authenticate before building the local Docker action"
+        required: false
     inputs:
       action_ref:
         description: "ec2-gha Git ref (branch/tag/SHA) to checkout"
@@ -161,6 +164,31 @@ jobs:
           role-to-assume: ${{ inputs.ec2_launch_role || vars.EC2_LAUNCH_ROLE }}
           role-session-name: github-actions-session
           aws-region: ${{ inputs.aws_region }}
+
+      - name: Check Docker Hub credentials
+        id: dockerhub-auth
+        env:
+          DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -n "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; then
+            echo "enabled=true" >> "${GITHUB_OUTPUT}"
+          else
+            if [ -z "${DOCKERHUB_USERNAME}" ]; then
+              echo "Skipping Docker Hub login because vars.DOCKERHUB_USERNAME is not configured."
+            fi
+            if [ -z "${DOCKERHUB_TOKEN}" ]; then
+              echo "Skipping Docker Hub login because secrets.DOCKERHUB_TOKEN is not configured."
+            fi
+            echo "enabled=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Log in to Docker Hub
+        if: steps.dockerhub-auth.outputs.enabled == 'true'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Create cloud runner
         id: aws-start

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Many of these fall back to corresponding `vars.*` (if not provided as `inputs`):
 - `runner_initial_grace_period` - Grace period in seconds before terminating instance if no jobs start (default: 180)
 - `runner_poll_interval` - How often (in seconds) to check termination conditions (default: 10)
 - `ssh_pubkey` - SSH public key (for [SSH access])
+- `vars.DOCKERHUB_USERNAME` and `secrets.DOCKERHUB_TOKEN` - Optional Docker Hub credentials used before building the local Docker action that launches the runner. The login step is skipped unless both are present. If you list secrets explicitly instead of using `secrets: inherit`, pass `DOCKERHUB_TOKEN` alongside `GH_SA_TOKEN`.
 
 ## Outputs <a id="outputs"></a>
 


### PR DESCRIPTION
## Summary

- declare an optional DOCKERHUB_TOKEN secret for the reusable runner workflow
- log in to Docker Hub before the local Docker action is built when both vars.DOCKERHUB_USERNAME and secrets.DOCKERHUB_TOKEN are present
- document the optional Docker Hub credentials for callers that do not use secrets: inherit

## Why

The reusable runner workflow builds this repository's Docker action on the GitHub-hosted launcher. That build pulls python:3.12 from Docker Hub, so authenticated pulls can avoid anonymous [pull limits and auth failures](https://github.com/m2lines/Samudra/actions/runs/27713076069/job/82732494816) before the EC2 runner is created.

We could alternatively make this required to avoid surprises but presumably it's working ok for existing users? LMK what you prefer.