### PR TITLE
Pull `python:3.12` base from `public.ecr.aws` mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM public.ecr.aws/docker/library/python:3.12
 
 ENV PYTHONUNBUFFERED=1
 RUN mkdir app


### PR DESCRIPTION
## Summary

Change the Docker action's base image from `python:3.12` (Docker Hub) to `public.ecr.aws/docker/library/python:3.12` (AWS's public mirror).

## Why

`runner.yml` builds this repo's Docker action (`Dockerfile`) on the GitHub-hosted launcher before the EC2 runner is created. That build pulls `python:3.12` from Docker Hub, which is subject to [anonymous pull rate limits](https://github.com/m2lines/Samudra/actions/runs/27713076069/job/82732494816) that can fail the build.

`public.ecr.aws/docker/library/python:3.12` is AWS's public mirror of the same official image — no auth, no anonymous pull limits — so this fixes the failures with **zero config** for all callers.

This is an alternative to #4 (optional Docker Hub login). The two aren't mutually exclusive, but this one solves the stated problem without requiring callers to configure `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`.

## Verification

Built locally with the ECR base — pulls anonymously, builds identically (`pip install /app` → `ec2_gha` + `gha_runner` wheels), `python -c "import ec2_gha"` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)